### PR TITLE
Add missing deasync dependency to 11ty plugin `package.json`

### DIFF
--- a/packages/eleventy-plugin-shiki-twoslash/package.json
+++ b/packages/eleventy-plugin-shiki-twoslash/package.json
@@ -20,6 +20,7 @@
     "build": "npx tsc index.js --declaration --allowJs --emitDeclarationOnly"
   },
   "dependencies": {
+    "deasync": "^0.1.21",
     "remark-shiki-twoslash": "1.4.2",
     "typescript": ">3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,11 +34,13 @@ importers:
 
   packages/eleventy-plugin-shiki-twoslash:
     specifiers:
+      deasync: ^0.1.21
       remark-shiki-twoslash: 1.4.2
       shiki: latest
       shiki-twoslash: 1.4.1
       typescript: '>3'
     dependencies:
+      deasync: 0.1.21
       remark-shiki-twoslash: link:../remark-shiki-twoslash
       typescript: 4.3.2
     devDependencies:
@@ -2950,7 +2952,6 @@ packages:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
     dependencies:
       file-uri-to-path: 1.0.0
-    dev: true
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3419,7 +3420,6 @@ packages:
     dependencies:
       bindings: 1.5.0
       node-addon-api: 1.7.2
-    dev: true
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -4199,7 +4199,6 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-    dev: true
 
   /filename-reserved-regex/2.0.0:
     resolution: {integrity: sha1-q/c9+rc10EVECr/qLZHzieu/oik=}
@@ -6868,7 +6867,6 @@ packages:
 
   /node-addon-api/1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
-    dev: true
 
   /node-int64/0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}


### PR DESCRIPTION
Was trying to use the 11ty plugin and the `deasync` dependency used was not listed in its `package.json`. This adds it.