### PR TITLE
Fix import of visit from unist-util-visit

### DIFF
--- a/packages/twoslash-cli/index.js
+++ b/packages/twoslash-cli/index.js
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from "fs
 import remark from "remark"
 import toHAST from "mdast-util-to-hast"
 import hastToHTML from "hast-util-to-html"
-import visit from "unist-util-visit"
+import { visit } from "unist-util-visit"
 import { join, dirname } from "path"
 import remarkShikiTwoslash from "remark-shiki-twoslash"
 import { basename, extname, sep } from "path"


### PR DESCRIPTION
Fixes #14

Unlike other packages, [twoslash-cli](https://github.com/shikijs/twoslash/tree/main/packages/twoslash-cli) depends on v3+ of [unist-util-visit](https://www.npmjs.com/package/unist-util-visit), which uses a single export for `visit` instead of a default one.

I have changed the import statement accordingly.