### PR TITLE
Use the jest module system to re-write shiki-twoslash to the dev build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,14 @@ These modules are built using test driven development, and so you can run:
 pnpm test --watch
 ```
 
-In the root of the repo to see how your changes affect the tests. Both `shiki-twoslash` and `remark-shiki-twoslash` uses a traditional unit-test style and `reamrk-shiki-twoslash` also contains an easy way to do integration-style tests where you give a markdown document and see the end result as a HTML file which you can inspect. 
+In the root of the repo to see how your changes affect the tests. Both `shiki-twoslash` and `remark-shiki-twoslash` uses a traditional unit-test style and `reamrk-shiki-twoslash` also contains an easy way to do integration-style tests where you add a markdown document to [`packages/remark-shiki-twoslash/test/fixtures`](packages/remark-shiki-twoslash/test/fixtures) and see the end result as a HTML file which you can inspect visually. 
+
+These two dependencies also use TypeScript, you can validate all of the TypeScript via `pnpm build`. 
 
 #### Integration Test Notes
 
 You can monitor a single markdown fixture via `pnpm test --watch --testNamePattern [filename]`. 
-To get underlying information about what Twoslash is doing you can run tests with the env var `DEBUG="*"`, this is very noisy - so narrow your test down.
-
-I've not yet figured out a way to have shiki-twoslash use the .ts files directly at this abstraction level, so you'll need to run `pnpm build` occasionally if you aren't seeing the expected changes in results.
-
-These two dependencies also use TypeScript, you can validate all of the TypeScript via `pnpm build`. 
+To get underlying information about what Twoslash is doing you can run tests with the env var `DEBUG="*"`, this is very noisy - so narrow your test down ahead of time.
 
 #### Examples
 

--- a/packages/remark-shiki-twoslash/test/fixtures.test.ts
+++ b/packages/remark-shiki-twoslash/test/fixtures.test.ts
@@ -1,5 +1,9 @@
+// Replace the dist build of shiki-twoslash with the dev build
+jest.mock("shiki-twoslash", () => {
+  return jest.requireActual("../../shiki-twoslash/src")
+})
+
 import gatsbyRemarkShiki from ".."
-import shikiTwoslash from "../../shiki-twoslash/src"
 
 const toHAST = require(`mdast-util-to-hast`)
 const hastToHTML = require(`hast-util-to-html`)
@@ -8,11 +12,10 @@ import { join, parse } from "path"
 import { toMatchFile } from "jest-file-snapshot"
 import { format } from "prettier"
 const remark = require("remark")
-import { Node } from "unist"
 expect.extend({ toMatchFile })
 
 const getHTML = async (code: string, settings: any) => {
-  const markdownAST: Node = remark().parse(code)
+  const markdownAST = remark().parse(code)
 
   await gatsbyRemarkShiki(settings)(markdownAST)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
 
   packages/docusaurus-preset-shiki-twoslash:
     specifiers:
-      remark-shiki-twoslash: 1.4.2
+      remark-shiki-twoslash: 1.4.3
       typescript: '>3'
     dependencies:
       remark-shiki-twoslash: link:../remark-shiki-twoslash
@@ -37,9 +37,9 @@ importers:
   packages/eleventy-plugin-shiki-twoslash:
     specifiers:
       deasync: ^0.1.21
-      remark-shiki-twoslash: 1.4.2
+      remark-shiki-twoslash: 1.4.3
       shiki: latest
-      shiki-twoslash: 1.4.1
+      shiki-twoslash: 1.4.2
       typescript: '>3'
     dependencies:
       deasync: 0.1.21
@@ -51,7 +51,7 @@ importers:
 
   packages/gatsby-remark-shiki-twoslash:
     specifiers:
-      remark-shiki-twoslash: 1.4.2
+      remark-shiki-twoslash: 1.4.3
       tslib: ^1.10.0
       typescript: '>3'
       unist-util-visit: ^2.0.0
@@ -64,7 +64,7 @@ importers:
 
   packages/hexo-shiki-twoslash:
     specifiers:
-      remark-shiki-twoslash: 1.4.2
+      remark-shiki-twoslash: 1.4.3
       typescript: '>3'
     dependencies:
       remark-shiki-twoslash: link:../remark-shiki-twoslash
@@ -77,9 +77,9 @@ importers:
       '@types/markdown-it': ^12.0.1
       deasync: ^0.1.21
       markdown-it: ^12.0.6
-      remark-shiki-twoslash: 1.4.2
+      remark-shiki-twoslash: 1.4.3
       shiki: latest
-      shiki-twoslash: 1.4.1
+      shiki-twoslash: 1.4.2
       tslib: ^1.10.0
       typescript: '>3'
     dependencies:
@@ -106,7 +106,7 @@ importers:
       regenerator-runtime: ^0.13.7
       rehype-stringify: ^6.0.1
       shiki: ^0.9.3
-      shiki-twoslash: 1.4.1
+      shiki-twoslash: 1.4.2
       tsdx: ^0.14.1
       tslib: 2.1.0
       typescript: '>3'
@@ -167,8 +167,8 @@ importers:
       hast-util-to-html: ^7.1.2
       mdast-util-to-hast: ^10.0.0
       remark: ^13.0.0
-      remark-shiki-twoslash: 1.4.2
-      shiki-twoslash: 1.4.1
+      remark-shiki-twoslash: 1.4.3
+      shiki-twoslash: 1.4.2
       typescript: ^3
       unist-util-visit: ^3.1.0
     dependencies:
@@ -186,7 +186,7 @@ importers:
 
   packages/vuepress-plugin-shiki-twoslash:
     specifiers:
-      remark-shiki-twoslash: 1.4.2
+      remark-shiki-twoslash: 1.4.3
       typescript: '>3'
     dependencies:
       remark-shiki-twoslash: link:../remark-shiki-twoslash


### PR DESCRIPTION
Abuse the Jest module mocking system to make the shiki-twoslash module lookup use the app's source-code instead of the built version.