### PR TITLE
fix: add algorithm for nesting tags

### DIFF
--- a/packages/remark-shiki-twoslash/test/fixtures.test.ts
+++ b/packages/remark-shiki-twoslash/test/fixtures.test.ts
@@ -16,8 +16,9 @@ expect.extend({ toMatchFile })
 
 const getHTML = async (code: string, settings: any) => {
   const markdownAST = remark().parse(code)
-
-  await gatsbyRemarkShiki(settings)(markdownAST)
+  
+  const customSettings = getSettingsFromMarkdown(code) || {}
+  await gatsbyRemarkShiki({...settings, ...customSettings})(markdownAST)
 
   // @ts-ignore
   const twoslashes = markdownAST.children.filter(c => c.meta && c.meta.includes("twoslash")).map(c => c.twoslash)
@@ -123,6 +124,12 @@ color: #ffeeee;
    z-index: 100;
 }
 
+data-err {
+  background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+  repeat-x bottom left;
+  padding-bottom: 3px;
+}
+
 </style>
 `
 
@@ -131,4 +138,19 @@ const cleanFixture = (text: string) => {
   return text
     .replace(new RegExp(wd, "g"), "[home]")
     .replace(/\/home\/runner\/work\/TypeScript-Website\/TypeScript-Website/g, "[home]")
+}
+
+
+function getSettingsFromMarkdown(fileContent) {
+  if (fileContent.startsWith("<!-- twoslash: {")) {
+    const code = fileContent.split("<!-- twoslash: ")[1].split(" -->")[0]
+    try {
+      return eval("const res = " + code + "; res")
+    } catch (error) {
+      console.error(
+        `Twoslash Fixture: Setting custom theme settings failed. The eval'd code is '${code}' which bailed:`
+      )
+      throw error
+    }
+  }
 }

--- a/packages/remark-shiki-twoslash/test/fixtures/accurateErrors.md
+++ b/packages/remark-shiki-twoslash/test/fixtures/accurateErrors.md
@@ -1,0 +1,17 @@
+<!-- twoslash: { themes: ["github-dark", "light-plus"]  } -->
+
+This should render two different codesamples, which have underlines just on the 'title'
+
+```ts twoslash
+// @errors: 2540
+
+interface Todo {
+title: string;
+}
+
+const todo: Readonly<Todo> = {
+    title: "Delete inactive users",
+};
+
+todo.title = "Hello";
+```

--- a/packages/remark-shiki-twoslash/test/results/accurateErrors.html
+++ b/packages/remark-shiki-twoslash/test/results/accurateErrors.html
@@ -1,0 +1,81 @@
+<!-- twoslash: { themes: ["github-dark", "light-plus"]  } -->
+<p>
+  This should render two different codesamples, which have underlines just on
+  the 'title'
+</p>
+<pre
+  class="shiki github-dark twoslash lsp"
+  style="background-color: #24292e; color: #e1e4e8"
+><div class="language-id">ts</div><div class='code-container'><code><div class='line'><span style="color: #F97583">interface</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0"><data-lsp lsp='interface Todo' >Todo</data-lsp></span><span style="color: #E1E4E8"> {</span></div><div class='line'><span style="color: #FFAB70"><data-lsp lsp='(property) Todo.title: string' >title</data-lsp></span><span style="color: #F97583">:</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF">string</span><span style="color: #E1E4E8">;</span></div><div class='line'><span style="color: #E1E4E8">}</span></div>
+<div class='line'><span style="color: #F97583">const</span><span style="color: #E1E4E8"> </span><span style="color: #79B8FF"><data-lsp lsp='const todo: Readonly&lt;Todo>' >todo</data-lsp></span><span style="color: #F97583">:</span><span style="color: #E1E4E8"> </span><span style="color: #B392F0"><data-lsp lsp='type Readonly&lt;T> = { readonly [P in keyof T]: T[P]; }' >Readonly</data-lsp></span><span style="color: #E1E4E8">&lt;</span><span style="color: #B392F0"><data-lsp lsp='interface Todo' >Todo</data-lsp></span><span style="color: #E1E4E8">&gt; </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> {</span></div><div class='line'><span style="color: #E1E4E8">    <data-lsp lsp='(property) title: string' >title</data-lsp>: </span><span style="color: #9ECBFF">"Delete inactive users"</span><span style="color: #E1E4E8">,</span></div><div class='line'><span style="color: #E1E4E8">};</span></div>
+<div class='line'><span style="color: #E1E4E8"><data-lsp lsp='const todo: Readonly&lt;Todo>' >todo</data-lsp>.<data-err><data-lsp lsp='(property) title: any' >title</data-lsp></data-err> </span><span style="color: #F97583">=</span><span style="color: #E1E4E8"> </span><span style="color: #9ECBFF">"Hello"</span><span style="color: #E1E4E8">;</span></div><span class="error"><span>Cannot assign to 'title' because it is a read-only property.</span><span class="code">2540</span></span><span class="error-behind">Cannot assign to 'title' because it is a read-only property.</span></code></div></pre>
+<pre
+  class="shiki light-plus twoslash lsp"
+  style="background-color: #ffffff; color: #000000"
+><div class="language-id">ts</div><div class='code-container'><code><div class='line'><span style="color: #0000FF">interface</span><span style="color: #000000"> </span><span style="color: #267F99"><data-lsp lsp='interface Todo' >Todo</data-lsp></span><span style="color: #000000"> {</span></div><div class='line'><span style="color: #001080"><data-lsp lsp='(property) Todo.title: string' >title</data-lsp></span><span style="color: #000000">: </span><span style="color: #267F99">string</span><span style="color: #000000">;</span></div><div class='line'><span style="color: #000000">}</span></div>
+<div class='line'><span style="color: #0000FF">const</span><span style="color: #000000"> </span><span style="color: #0070C1"><data-lsp lsp='const todo: Readonly&lt;Todo>' >todo</data-lsp></span><span style="color: #000000">: </span><span style="color: #267F99"><data-lsp lsp='type Readonly&lt;T> = { readonly [P in keyof T]: T[P]; }' >Readonly</data-lsp></span><span style="color: #000000">&lt;</span><span style="color: #267F99"><data-lsp lsp='interface Todo' >Todo</data-lsp></span><span style="color: #000000">&gt; = {</span></div><div class='line'><span style="color: #000000">    </span><span style="color: #001080"><data-lsp lsp='(property) title: string' >title</data-lsp>:</span><span style="color: #000000"> </span><span style="color: #A31515">"Delete inactive users"</span><span style="color: #000000">,</span></div><div class='line'><span style="color: #000000">};</span></div>
+<div class='line'><span style="color: #001080"><data-lsp lsp='const todo: Readonly&lt;Todo>' >todo</data-lsp></span><span style="color: #000000">.</span><span style="color: #001080"><data-err><data-lsp lsp='(property) title: any' >title</data-lsp></data-err></span><span style="color: #000000"> = </span><span style="color: #A31515">"Hello"</span><span style="color: #000000">;</span></div><span class="error"><span>Cannot assign to 'title' because it is a read-only property.</span><span class="code">2540</span></span><span class="error-behind">Cannot assign to 'title' because it is a read-only property.</span></code></div></pre>
+
+<style>
+  .shiki {
+    background-color: lightgrey;
+    padding: 8px;
+  }
+
+  .error,
+  .error-behind {
+    margin-left: -20px;
+    margin-right: -12px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+    padding: 6px;
+    padding-left: 14px;
+
+    white-space: pre-wrap;
+    display: block;
+  }
+
+  .error {
+    position: absolute;
+    background-color: #ffeeee;
+    border-left: 2px solid #bf1818;
+    width: 100%;
+
+    display: flex;
+    align-items: center;
+    color: black;
+  }
+
+  .error-behind {
+    user-select: none;
+    color: #ffeeee;
+  }
+  .query {
+    color: white;
+  }
+
+  /* To get them all hovering OOTB: .twoslash data-lsp::before { */
+
+  .twoslash data-lsp:hover::before {
+    content: attr(lsp);
+    position: absolute;
+    transform: translate(0, 1rem);
+
+    background-color: #3f3f3f;
+    color: #fff;
+    text-align: left;
+    padding: 5px 8px;
+    border-radius: 2px;
+    font-family: "JetBrains Mono", Menlo, Monaco, Consolas, Courier New,
+      monospace;
+    font-size: 14px;
+    white-space: pre-wrap;
+    z-index: 100;
+  }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
+</style>

--- a/packages/remark-shiki-twoslash/test/results/accurateErrors.json
+++ b/packages/remark-shiki-twoslash/test/results/accurateErrors.json
@@ -1,0 +1,95 @@
+[
+  {
+    "code": "\ninterface Todo {\ntitle: string;\n}\n\nconst todo: Readonly<Todo> = {\n    title: \"Delete inactive users\",\n};\n\ntodo.title = \"Hello\";",
+    "extension": "ts",
+    "highlights": [],
+    "queries": [],
+    "staticQuickInfos": [
+      {
+        "text": "interface Todo",
+        "docs": "",
+        "start": 11,
+        "length": 4,
+        "line": 1,
+        "character": 10,
+        "targetString": "Todo"
+      },
+      {
+        "text": "(property) Todo.title: string",
+        "docs": "",
+        "start": 18,
+        "length": 5,
+        "line": 2,
+        "character": 0,
+        "targetString": "title"
+      },
+      {
+        "text": "const todo: Readonly<Todo>",
+        "docs": "",
+        "start": 42,
+        "length": 4,
+        "line": 5,
+        "character": 6,
+        "targetString": "todo"
+      },
+      {
+        "text": "type Readonly<T> = { readonly [P in keyof T]: T[P]; }",
+        "docs": "Make all properties in T readonly",
+        "start": 48,
+        "length": 8,
+        "line": 5,
+        "character": 12,
+        "targetString": "Readonly"
+      },
+      {
+        "text": "interface Todo",
+        "docs": "",
+        "start": 57,
+        "length": 4,
+        "line": 5,
+        "character": 21,
+        "targetString": "Todo"
+      },
+      {
+        "text": "(property) title: string",
+        "docs": "",
+        "start": 71,
+        "length": 5,
+        "line": 6,
+        "character": 4,
+        "targetString": "title"
+      },
+      {
+        "text": "const todo: Readonly<Todo>",
+        "docs": "",
+        "start": 107,
+        "length": 4,
+        "line": 9,
+        "character": 0,
+        "targetString": "todo"
+      },
+      {
+        "text": "(property) title: any",
+        "docs": "",
+        "start": 112,
+        "length": 5,
+        "line": 9,
+        "character": 5,
+        "targetString": "title"
+      }
+    ],
+    "errors": [
+      {
+        "category": 1,
+        "code": 2540,
+        "length": 5,
+        "start": 112,
+        "line": 9,
+        "character": 5,
+        "renderedMessage": "Cannot assign to 'title' because it is a read-only property.",
+        "id": "err-2540-112-5"
+      }
+    ],
+    "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEFMCdoe2gZwFygEwFYAsAGAUHgJYB2ALjAGYCGAxpKACpwAmcoA3nqYaQDaSpEpaCQDmAbjwBfAjTjEhoUizioASpCqtivAJ4AeJqwB8oALwc8oa0p79UAIgAikfuVAla3AG70ArogwiA4ANNKSXCoAdNx89BYOABKuvHAO4kA"
+  }
+]

--- a/packages/remark-shiki-twoslash/test/results/codefenceHighlight.html
+++ b/packages/remark-shiki-twoslash/test/results/codefenceHighlight.html
@@ -66,4 +66,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/exporting.html
+++ b/packages/remark-shiki-twoslash/test/results/exporting.html
@@ -62,4 +62,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/generics.html
+++ b/packages/remark-shiki-twoslash/test/results/generics.html
@@ -65,4 +65,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/highlight.html
+++ b/packages/remark-shiki-twoslash/test/results/highlight.html
@@ -60,4 +60,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/importNodeTypes.html
+++ b/packages/remark-shiki-twoslash/test/results/importNodeTypes.html
@@ -66,4 +66,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/inline-angle-brackets.html
+++ b/packages/remark-shiki-twoslash/test/results/inline-angle-brackets.html
@@ -72,4 +72,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/large-chopped.html
+++ b/packages/remark-shiki-twoslash/test/results/large-chopped.html
@@ -73,4 +73,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/one.html
+++ b/packages/remark-shiki-twoslash/test/results/one.html
@@ -60,4 +60,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/simple-interface.html
+++ b/packages/remark-shiki-twoslash/test/results/simple-interface.html
@@ -60,4 +60,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/simple.html
+++ b/packages/remark-shiki-twoslash/test/results/simple.html
@@ -61,4 +61,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/twoliner.html
+++ b/packages/remark-shiki-twoslash/test/results/twoliner.html
@@ -60,4 +60,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/remark-shiki-twoslash/test/results/usingJSX.html
+++ b/packages/remark-shiki-twoslash/test/results/usingJSX.html
@@ -77,4 +77,10 @@
     white-space: pre-wrap;
     z-index: 100;
   }
+
+  data-err {
+    background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+      repeat-x bottom left;
+    padding-bottom: 3px;
+  }
 </style>

--- a/packages/shiki-twoslash/src/utils.ts
+++ b/packages/shiki-twoslash/src/utils.ts
@@ -8,49 +8,89 @@ type Range = {
   lsp?: string
 }
 
-const splice = (str: string, idx: number, rem: number, newString: string) =>
-  str.slice(0, idx) + newString + str.slice(idx + Math.abs(rem))
-
 /**
  * We're given the text which lives inside the token, and this function will
  * annotate it with twoslash metadata
  */
 export function createHighlightedString(ranges: Range[], text: string, targetedWord: string = "") {
-  const actions = [] as { text: string; index: number }[]
-  let hasErrors = false
-
   // Why the weird chars? We need to make sure that generic syntax isn't
   // interpreted as html tags - to do that we need to switch out < to &lt; - *but*
   // making that transition changes the indexes because it's gone from 1 char to 4 chars
-
+  //
   // So, use an obscure character to indicate a real < for HTML, then switch it after
-
-  ranges.forEach(r => {
-    if (r.classes === "lsp") {
-      // console.log(ranges, text, targetedWord)
-      // The LSP response lives inside a dom attribute, which _can_ have < inside it, so switch them ahead of time.
-      const lsp = htmlAttrReplacer(r.lsp || "")
-      const underLineTargetedWord = r.lsp === targetedWord ? "style=⇯border-bottom: solid 2px lightgrey;⇯" : ""
-      actions.push({ text: "⇍/data-lsp⇏", index: r.end })
-      actions.push({ text: `⇍data-lsp lsp=¿${lsp}¿ ${underLineTargetedWord}⇏`, index: r.begin })
-    } else if (r.classes === "err") {
-      hasErrors = true
-    } else if (r.classes === "query") {
-      actions.push({ text: "⇍/data-highlight⇏", index: r.end })
-      actions.push({ text: `⇍data-highlight'⇏`, index: r.begin })
+  const tag = (x: string) => `⇍${x}⇏`
+  const makeTagFromRange = (r: Range, close?: true) => {
+    switch (r.classes) {
+      case "lsp":
+        // The LSP response lives inside a dom attribute, which _can_ have < inside it, so switch them ahead of time.
+        const lsp = htmlAttrReplacer(r.lsp || "")
+        const underLineTargetedWord = r.lsp === targetedWord ? "style=⇯border-bottom: solid 2px lightgrey;⇯" : ""
+        return close ? tag("/data-lsp") : tag(`data-lsp lsp=¿${lsp}¿ ${underLineTargetedWord}`)
+      case "query":
+        return tag(`${close ? "/" : ""}data-highlight`)
+      // handle both unknown and err variant as error-tag
+      // case "err": is not required, just to be useful for others
+      case "err":
+      default:
+        return tag(`${close ? "/" : ""}data-err`)
     }
-  })
+  }
 
-  let html = (" " + text).slice(1)
+  ranges.sort((a, b) => {
+    // Order of precedence
+    // if two same offset meet, the lsp will be put as innermost than err and query
+    const precedenceOf = (x?: string) => ["err", "query", "lsp"].indexOf(x ?? "")
 
-  // Apply all the edits
-  actions
-    .sort((l, r) => r.index - l.index)
-    .forEach(action => {
-      html = splice(html, action.index, 0, action.text)
-    })
+    let cmp = 0
+    // Can be desugared into,
+    // 1. compare based on smaller begin, !(cmp) means if it's 0 then
+    // 2. compare based on bigger end, ^ same thing again then
+    // 3. compare based on higher precedence
+    // && is so that if a step made cmp to something other than 0, it stops
+    /***1*/ !(cmp = a.begin - b.begin) &&
+      /*2*/ !(cmp = b.end - a.end) &&
+      /*3*/ !(cmp = precedenceOf(a.classes) - precedenceOf(b.classes))
+    return cmp
+  }) // `Array.sort` works in place
 
-  if (hasErrors) html = `⇍data-err⇏${html}⇍/data-err⇏`
+  // Marks how much of the text has been put into the output/html
+  let cursor = 0
+  // should be maximum of O(n) where n is length of ranges
+  const nest = (data: typeof ranges) => {
+    let stack = ""
+    const top = data.shift()! // I have made sure data can't be empty
+
+    // parse from cursor to top.begin to make sure
+    // strings on the way are parsed
+    stack += text.substring(cursor, top.begin)
+    cursor = top.begin
+
+    // open tag
+    stack += makeTagFromRange(top)
+
+    // if the data still have an element that's in the top's range
+    if (data.some(x => x.begin < top.end)) {
+      stack += nest(data)
+    } else {
+      // othewise slice the text and set cursor
+      stack += text.substring(top.begin, top.end)
+      cursor = top.end
+    }
+
+    // close tag
+    stack += makeTagFromRange(top, true)
+
+    // if the tag is complete but still have some data left in the range
+    if (data.length !== 0) {
+      stack += nest(data)
+    }
+
+    return stack
+  }
+
+  // cloned because I don't feel comfortable modifying this as a side-effect from recursion
+  const data = JSON.parse(JSON.stringify(ranges))
+  const html = nest(data) + text.substring(cursor) // nested + leftover texts
 
   return htmlAttrUnReplacer(replaceTripleArrow(stripHTML(html)))
 }


### PR DESCRIPTION
This PR adds an algorithm to nest these tags correctly. It (at least locally) passes all the tests and highlight properly with all the default themes from shiki.

Closes #25