### PR TITLE
Ensure all types in the READMEs are up to date

### DIFF
--- a/markdown.config.js
+++ b/markdown.config.js
@@ -1,0 +1,11 @@
+const fs = require('fs')
+const path = require('path')
+const markdownMagic = require('markdown-magic')
+
+const config = {
+  transforms: {
+    TYPE: require('markdown-magic-inline-types')
+  }
+}
+
+markdownMagic("packages/*/README.md", config)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "bootstrap": "pnpm build -r --workspace-concurrency 1 && md-magic --path 'packages/*/README.md'",
+    "bootstrap": "pnpm build -r --workspace-concurrency 1 && md-magic",
     "build": "pnpm run build -r"
   },
   "devDependencies": {
@@ -16,6 +16,7 @@
     "glob": "^7.1.7",
     "jest": "^27.0.5",
     "markdown-magic": "^2.2.0",
+    "markdown-magic-inline-types": "^1.0.2",
     "pleb": "^3.4.4",
     "prettier": "^2.3.1",
     "typescript": "^4.3.4"

--- a/packages/shiki-twoslash/README.md
+++ b/packages/shiki-twoslash/README.md
@@ -45,51 +45,64 @@ const b = "345"
 
 ### User Settings
 
-The config which a user passes is an intersection of Shiki's [`HighlighterOptions`](https://unpkg.com/shiki/dist/index.d.ts)
+The config which you pass in is a mix of Shiki's [`HighlighterOptions`](https://unpkg.com/shiki/dist/index.d.ts)
 
+<!-- AUTO-GENERATED-CONTENT:START (TYPE:src=./packages/shiki-twoslash/node_modules/shiki/dist/index.d.ts&symbol=HighlighterOptions) -->
 ```ts
 interface HighlighterOptions {
-  theme?: IThemeRegistration
-  langs?: (Lang | ILanguageRegistration)[]
-  themes?: IThemeRegistration[]
-  paths?: IHighlighterPaths
+    theme?: IThemeRegistration;
+    langs?: (Lang | ILanguageRegistration)[];
+    themes?: IThemeRegistration[];
+    /**
+     * Paths for loading themes and langs. Relative to the package's root.
+     */
+    paths?: IHighlighterPaths;
 }
 ```
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 
 With twoslash's [`TwoSlashOptions`](https://unpkg.com/@typescript/twoslash/dist/index.d.ts)
 
+<!-- AUTO-GENERATED-CONTENT:START (TYPE:src=./node_modules/@typescript/twoslash/dist/index.d.ts&symbol=TwoSlashOptions) -->
 ```ts
 export interface TwoSlashOptions {
-  /** Allows setting any of the handbook options from outside the function, useful if you don't want LSP identifiers */
-  defaultOptions?: Partial<ExampleOptions>
-  /** Allows setting any of the compiler options from outside the function */
-  defaultCompilerOptions?: CompilerOptions
-  /** Allows applying custom transformers to the emit result, only useful with the showEmit output */
-  customTransformers?: CustomTransformers
-  /** An optional copy of the TypeScript import, if missing it will be require'd. */
-  tsModule?: TS
-  /** An optional copy of the lz-string import, if missing it will be require'd. */
-  lzstringModule?: LZ
-  /**
-   * An optional Map object which is passed into @typescript/vfs - if you are using twoslash on the
-   * web then you'll need this to set up your lib *.d.ts files. If missing, it will use your fs.
-   */
-  fsMap?: Map<string, string>
-  /** The cwd for the folder which the virtual fs should be overlaid on top of when using local fs, opts to process.cwd() if not present */
-  vfsRoot?: string
+    /** Allows setting any of the handbook options from outside the function, useful if you don't want LSP identifiers */
+    defaultOptions?: Partial<ExampleOptions>;
+    /** Allows setting any of the compiler options from outside the function */
+    defaultCompilerOptions?: CompilerOptions;
+    /** Allows applying custom transformers to the emit result, only useful with the showEmit output */
+    customTransformers?: CustomTransformers;
+    /** An optional copy of the TypeScript import, if missing it will be require'd. */
+    tsModule?: TS;
+    /** An optional copy of the lz-string import, if missing it will be require'd. */
+    lzstringModule?: LZ;
+    /**
+     * An optional Map object which is passed into @typescript/vfs - if you are using twoslash on the
+     * web then you'll need this to set up your lib *.d.ts files. If missing, it will use your fs.
+     */
+    fsMap?: Map<string, string>;
+    /** The cwd for the folder which the virtual fs should be overlaid on top of when using local fs, opts to process.cwd() if not present */
+    vfsRoot?: string;
 }
 ```
+<!-- AUTO-GENERATED-CONTENT:END -->
+
 
 And one extra for good luck:
 
+<!-- AUTO-GENERATED-CONTENT:START (TYPE:src=./packages/shiki-twoslash/src/index.ts&symbol=TwoslashShikiOptions) -->
 ```ts
 export interface TwoslashShikiOptions {
-  /** A way to turn on the try buttons seen on the TS website */
-  addTryButton?: true
-  /** A way to disable implicit React imports on tsx/jsx language codeblocks */
-  disableImplicitReactImport?: true
+    /** A way to turn on the try buttons seen on the TS website */
+    addTryButton?: true;
+    /** A way to disable implicit React imports on tsx/jsx language codeblocks */
+    disableImplicitReactImport?: true;
+    /** A way to add a div wrapper for multi-theme outputs */
+    wrapFragments?: true;
 }
 ```
+<!-- AUTO-GENERATED-CONTENT:END -->
 
 That said, most people will just want to set a `theme`:
 
@@ -160,6 +173,8 @@ async function visitor(highlighterOpts) {
 ```
 
 ##### `renderCodeToHTML`
+
+
 
 ```ts
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ importers:
       glob: ^7.1.7
       jest: ^27.0.5
       markdown-magic: ^2.2.0
+      markdown-magic-inline-types: ^1.0.2
       pleb: ^3.4.4
       prettier: ^2.3.1
       typescript: ^4.3.4
@@ -22,6 +23,7 @@ importers:
       glob: 7.1.7
       jest: 27.0.5
       markdown-magic: 2.2.0
+      markdown-magic-inline-types: 1.0.2
       pleb: 3.4.4
       prettier: 2.3.1
       typescript: 4.3.4
@@ -7332,6 +7334,12 @@ packages:
   /markdown-link/0.1.1:
     resolution: {integrity: sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /markdown-magic-inline-types/1.0.2:
+    resolution: {integrity: sha512-LRJCxpQGbOlUp6v9kCc0nR0EGQvlZbNx2+BpiLFllPkCkINESWQa/jOAHCfFFe4FTj9LgLlocEDP1pSNBu4wgg==}
+    dependencies:
+      typescript: 4.3.4
     dev: true
 
   /markdown-magic/2.2.0:


### PR DESCRIPTION
I built https://github.com/orta/markdown-magic-inline-types to keep these in sync