### PR TITLE
JSDoc support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "bootstrap": "pnpm build -r --workspace-concurrency 1 && md-magic",
-    "build": "pnpm run build -r"
+    "build": "pnpm run build -r && md-magic"
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",

--- a/packages/remark-shiki-twoslash/src/index.ts
+++ b/packages/remark-shiki-twoslash/src/index.ts
@@ -32,7 +32,7 @@ function getHTML(
   if ((lang as string) === "twoslash") {
     if (!metaString) throw new Error("A twoslash code block needs a pragma like 'twoslash include [name]'")
     addIncludes(includes, code, metaString)
-    results = wrapFragments ? `<div class="shiki-twoslash-fragment"></div>` : ""
+    results = twoslashSettings.wrapFragments ? `<div class="shiki-twoslash-fragment"></div>` : ""
   } else {
     // All good, get each highlighter and render the shiki output for it
     const output = highlighters.map(highlighter => {

--- a/packages/remark-shiki-twoslash/src/index.ts
+++ b/packages/remark-shiki-twoslash/src/index.ts
@@ -185,5 +185,5 @@ export const transformAttributesToHTML = (
 ) => {
   const twoslash = runTwoSlashOnNode(code, lang, attrs, settings)
   const newCode = (twoslash && twoslash.code) || code
-  return getHTML(newCode, lang, attrs, highlighters, twoslash)
+  return getHTML(newCode, lang, attrs, highlighters, twoslash, settings)
 }

--- a/packages/remark-shiki-twoslash/src/index.ts
+++ b/packages/remark-shiki-twoslash/src/index.ts
@@ -16,7 +16,7 @@ function getHTML(
   metaString: string,
   highlighters: Highlighter[],
   twoslash: TwoSlashReturn | undefined,
-  wrapFragments?: true
+  twoslashSettings: UserConfigSettings
 ) {
   // Shiki doesn't respect json5 as an input, so switch it
   // to json, which can handle comments in the syntax highlight
@@ -38,10 +38,10 @@ function getHTML(
     const output = highlighters.map(highlighter => {
       // @ts-ignore
       const themeName: string = highlighter.customName.split("/").pop().replace(".json", "")
-      return renderCodeToHTML(code, lang, metaString.split(" "), { themeName }, highlighter, twoslash)
+      return renderCodeToHTML(code, lang, metaString.split(" "), { themeName, ...twoslashSettings }, highlighter, twoslash)
     })
     results = output.join("\n")
-    if (highlighters.length > 1 && wrapFragments) {
+    if (highlighters.length > 1 && twoslashSettings.wrapFragments) {
       results = `<div class="shiki-twoslash-fragment">${results}</div>`
     }
   }
@@ -152,7 +152,7 @@ export const remarkVisitor =
       node.twoslash = twoslash
     }
 
-    const shikiHTML = getHTML(node.value, lang, metaString, highlighters, twoslash, twoslashSettings.wrapFragments)
+    const shikiHTML = getHTML(node.value, lang, metaString, highlighters, twoslash, twoslashSettings)
     node.type = "html"
     node.value = shikiHTML
     node.children = []

--- a/packages/remark-shiki-twoslash/test/results/jsdocInlineAttributes.html
+++ b/packages/remark-shiki-twoslash/test/results/jsdocInlineAttributes.html
@@ -6,7 +6,7 @@
 <pre
   class="shiki light-plus twoslash lsp"
   style="background-color: #ffffff; color: #000000"
-><div class="language-id">ts</div><div class='code-container'><code><div class='line'><span style="color: #008000">/** ABCDE */</span></div><div class='line'><span style="color: #0000FF">const</span><span style="color: #000000"> </span><span style="color: #0070C1"><data-lsp lsp='const a: "OK"' >a</data-lsp></span><span style="color: #000000"> = </span><span style="color: #A31515">"OK"</span></div></code></div></pre>
+><div class="language-id">ts</div><div class='code-container'><code><div class='line'><span style="color: #008000">/** ABCDE */</span></div><div class='line'><span style="color: #0000FF">const</span><span style="color: #000000"> </span><span style="color: #0070C1"><data-lsp lsp='ABCDE&#10;&#10;const a: "OK"' >a</data-lsp></span><span style="color: #000000"> = </span><span style="color: #A31515">"OK"</span></div></code></div></pre>
 
 <style>
   .shiki {

--- a/packages/shiki-twoslash/README.md
+++ b/packages/shiki-twoslash/README.md
@@ -100,6 +100,8 @@ export interface TwoslashShikiOptions {
     disableImplicitReactImport?: true;
     /** A way to add a div wrapper for multi-theme outputs */
     wrapFragments?: true;
+    /** Include JSDoc comments in the hovers */
+    includeJSDocInHover?: true;
 }
 ```
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/packages/shiki-twoslash/src/index.ts
+++ b/packages/shiki-twoslash/src/index.ts
@@ -13,6 +13,8 @@ export interface TwoslashShikiOptions {
   disableImplicitReactImport?: true
   /** A way to add a div wrapper for multi-theme outputs */
   wrapFragments?: true
+  /** Include JSDoc comments in the hovers */
+  includeJSDocInHover?: true
 }
 
 /** The possible user config, a combination of all shiki, twoslash and twoslash-shiki options */
@@ -51,6 +53,7 @@ export const createShikiHighlighter = (options: HighlighterOptions) => {
  * @param code the source code to render
  * @param lang the language to use in highlighting
  * @param info additional metadata which lives after the code-fence lang (e.g. ["twoslash"])
+ * @param shikiOptions user settings
  * @param highlighter optional, but you should use it, highlighter
  * @param twoslash optional, but required when info contains 'twoslash' as a string
  */
@@ -58,7 +61,7 @@ export const renderCodeToHTML = (
   code: string,
   lang: string,
   info: string[],
-  shikiOptions?: HtmlRendererOptions,
+  shikiOptions?: UserConfigSettings,
   highlighter?: Highlighter,
   twoslash?: TwoSlashReturn
 ) => {

--- a/packages/shiki-twoslash/src/index.ts
+++ b/packages/shiki-twoslash/src/index.ts
@@ -61,7 +61,7 @@ export const renderCodeToHTML = (
   code: string,
   lang: string,
   info: string[],
-  shikiOptions?: UserConfigSettings,
+  shikiOptions?: UserConfigSettings & { themeName: string },
   highlighter?: Highlighter,
   twoslash?: TwoSlashReturn
 ) => {

--- a/packages/shiki-twoslash/src/renderers/twoslash.ts
+++ b/packages/shiki-twoslash/src/renderers/twoslash.ts
@@ -26,6 +26,7 @@ import { HtmlRendererOptions, preOpenerFromRenderingOptsWithExtras } from "./pla
 export function twoslashRenderer(lines: Lines, options: HtmlRendererOptions & TwoslashShikiOptions, twoslash: TwoSlash, codefenceMeta: any) {
   let html = ""
 
+  console.log({options})
   const hasHighlight = shouldBeHighlightable(codefenceMeta)
   const hl = shouldHighlightLine(codefenceMeta)
 
@@ -121,7 +122,8 @@ export function twoslashRenderer(lines: Lines, options: HtmlRendererOptions & Tw
             if ("kind" in token) range.classes = token.kind
             if ("targetString" in token) {
               range.classes = "lsp"
-              range["lsp"] = token.text
+              const lspText = options.includeJSDocInHover && token.docs ? `${token.docs}\n\n${token.text}` : token.text
+              range["lsp"] = lspText
             }
             return range
           })

--- a/packages/shiki-twoslash/src/renderers/twoslash.ts
+++ b/packages/shiki-twoslash/src/renderers/twoslash.ts
@@ -26,7 +26,6 @@ import { HtmlRendererOptions, preOpenerFromRenderingOptsWithExtras } from "./pla
 export function twoslashRenderer(lines: Lines, options: HtmlRendererOptions & TwoslashShikiOptions, twoslash: TwoSlash, codefenceMeta: any) {
   let html = ""
 
-  console.log({options})
   const hasHighlight = shouldBeHighlightable(codefenceMeta)
   const hl = shouldHighlightLine(codefenceMeta)
 


### PR DESCRIPTION
The only thing here was that we didn't have a full pipeline for options to go from user input all the way to a renderer and now we do.

<img width="278" alt="Screen Shot 2021-07-11 at 8 35 41 AM" src="https://user-images.githubusercontent.com/49038/125186600-2e182880-e223-11eb-8656-13535f70dc74.png">
