### PR TITLE
fix(docusaurus-preset): fix text collection for copy button

### DIFF
--- a/.changeset/dull-boats-switch.md
+++ b/.changeset/dull-boats-switch.md
@@ -1,0 +1,5 @@
+---
+"docusaurus-preset-shiki-twoslash": patch
+---
+
+Fix copy button not working on production.

--- a/packages/docusaurus-preset-shiki-twoslash/docusaurus-theme-shiki-twoslash/theme/CodeBlock/index.js
+++ b/packages/docusaurus-preset-shiki-twoslash/docusaurus-theme-shiki-twoslash/theme/CodeBlock/index.js
@@ -13,7 +13,7 @@ const CodeBlock = ({ children, ...props }) => {
 
   const handleCopyCode = () => {
     if (pre.current) {
-      copy([...(pre.current.querySelectorAll("code div.line") ?? [])].map(el => el.textContent).join("\n"))
+      copy(Array.from(pre.current.querySelectorAll("code div.line")).map(el => el.textContent).join("\n"))
     }
     setShowCopied(true)
     setTimeout(() => setShowCopied(false), 2000)


### PR DESCRIPTION
Hi! 👋🏽 

This PR proposes a fix to a bug found when investigating https://github.com/remotion-dev/remotion/issues/496: the copy button works fine in development but doesn't work in production.

After investigation, I noticed the reason being the "cast" of `pre.current.querySelectorAll` to an array.

I created a repo with a reproducible scenario and more information about the issue and the proposed fix: https://github.com/arthurdenner/docusaurus-twoslash-bug