### PR TITLE
Remove trailing newline in code blocks before twoslash processing

### DIFF
--- a/.changeset/kind-gifts-agree.md
+++ b/.changeset/kind-gifts-agree.md
@@ -1,0 +1,5 @@
+---
+"markdown-it-shiki-twoslash": major
+---
+
+Remove extra trailing newline in code blocks before twoslash processing

--- a/packages/markdown-it-shiki-twoslash/src/index.ts
+++ b/packages/markdown-it-shiki-twoslash/src/index.ts
@@ -35,6 +35,7 @@ export const markdownItShikiTwoslashSetup = async (settings: UserConfigSettings)
 
   return (markdownit, options) => {
     markdownit.options.highlight = (code, lang, attrs) => {
+      code = code.replace(/\r?\n$/, "") // strip trailing newline fed during code block parsing
       return transformAttributesToHTML(code, [lang, attrs].join(" "), highlighters, options!)
     }
   }

--- a/packages/markdown-it-shiki-twoslash/test/markdown-it.test.ts
+++ b/packages/markdown-it-shiki-twoslash/test/markdown-it.test.ts
@@ -26,5 +26,7 @@ OK world
 
     const html = md.render(file)
     expect(html).toContain("shiki nord twoslash lsp")
+    const numberOfLines = html.match(/div class='line'/g)?.length
+    expect(numberOfLines).toBe(3)
   })
 })


### PR DESCRIPTION
markdown-it's parser produces code blocks with a trailing newline,
seemingly in conformance with the
[commonmark spec](https://spec.commonmark.org/0.12/#indented-code-blocks).
shiki-twoslash should avoid treating this line as contentful, as doing
so results in generated html with a "line" for that newline, adding an
extra newline to the user-provided code block. To avoid this unexpected
behavior, simply remove the trailing newline before twoslash-shiki
processing.

Closes #90