### PR TITLE
Remove trailing newline

### DIFF
--- a/.changeset/tidy-beans-shout.md
+++ b/.changeset/tidy-beans-shout.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-shiki-twoslash": patch
+---
+
+Automatically remove trailing newlines

--- a/packages/eleventy-plugin-shiki-twoslash/index.js
+++ b/packages/eleventy-plugin-shiki-twoslash/index.js
@@ -23,7 +23,8 @@ module.exports = function (eleventyConfig, options = {}) {
     }
   }
 
-  eleventyConfig.addMarkdownHighlighter((code, lang, fence) =>
-    transformAttributesToHTML(code, [lang, fence].join(" "), highlighters, options)
-  )
+  eleventyConfig.addMarkdownHighlighter((code, lang, fence) => {
+    code = code.replace(/\r?\n$/, "") // strip trailing newline fed during code block parsing
+    return transformAttributesToHTML(code, [lang, fence].join(" "), highlighters, options)
+  })
 }


### PR DESCRIPTION
This PR fixed the same issue fixed in PR: https://github.com/shikijs/twoslash/commit/d34ecb58ea391c7e81fc554b2515f9811ba2a1af for markdown-it.
Credits: @ayazhafiz