### PR TITLE
shiki-twoslash: fix HTML comment syntax

### DIFF
--- a/.changeset/unlucky-keys-sing.md
+++ b/.changeset/unlucky-keys-sing.md
@@ -1,0 +1,5 @@
+---
+"shiki-twoslash": patch
+---
+
+shiki-twoslash: fix HTML comment syntax when we can't find a language for the code sample

--- a/packages/shiki-twoslash/src/index.ts
+++ b/packages/shiki-twoslash/src/index.ts
@@ -92,7 +92,7 @@ export const renderCodeToHTML = (
   } catch (error) {
     // Shiki doesn't know this lang, so render it as plain text, but
     // also add a note at the end as a HTML comment
-    const note = `<!-- Note from shiki-twoslash: the language ${lang} was not set up for Shiki to use, and so there is no code highlighting --!>`
+    const note = `<!-- Note from shiki-twoslash: the language ${lang} was not set up for Shiki to use, and so there is no code highlighting -->`
     return plainTextRenderer(code, renderOpts, meta) + note
   }
 


### PR DESCRIPTION
Ref: https://developer.mozilla.org/en-US/docs/Web/API/Comment