### PR TITLE
Uses the PnP API to derive a safe cache folder

### DIFF
--- a/.changeset/eight-drinks-march.md
+++ b/.changeset/eight-drinks-march.md
@@ -1,0 +1,5 @@
+---
+"remark-shiki-twoslash": patch
+---
+
+Fixes remark-shiki-twoslash when used in PnP projects

--- a/packages/remark-shiki-twoslash/src/caching.ts
+++ b/packages/remark-shiki-twoslash/src/caching.ts
@@ -28,10 +28,23 @@ export const cachedTwoslashCall = (
   const shikiVersion = require('@typescript/twoslash/package.json').version
   const shasum = createHash("sha1")
   const codeSha = shasum.update(`${code}-${shikiVersion}`).digest("hex")
-  let cacheRoot = join(__dirname, "..", "..", ".cache", "twoslash")
-  if (__dirname.includes("node_modules")) {
-    cacheRoot = join(__dirname.split("node_modules")[0], ".cache", "twoslash")
-  }
+
+  const getNmCache = () => {
+    if (__dirname.includes("node_modules")) {
+      return join(__dirname.split("node_modules")[0], ".cache", "twoslash")
+    } else {
+      return join(__dirname, "..", "..", ".cache", "twoslash");
+    }
+  };
+
+  const getPnpCache = () => {
+    const pnp = require("pnpapi");
+    return join(pnp.getPackageInformation(pnp.topLevelLocator).packageLocation, "node_modules", ".cache", "twoslash");
+  };
+
+  const cacheRoot = process.env.pnp
+    ? getPnpCache()
+    : getNmCache();
 
   const cachePath = join(cacheRoot, `${codeSha}.json`)
 


### PR DESCRIPTION
When installed under Yarn w/ PnP, packages are mounted as readonly zip archives. As a result, the remark caching logic that currently tries to locate the node_modules from `__dirname` results in the artifacts being written into the (read-only) archive, thus failing.

This diff fixes that by checking whether the current process operates under PnP mode, and using the PnP API in that case (which is a sounder way to get the project root anyway).