### PR TITLE
Fixes typo

### DIFF
--- a/.changeset/great-adults-sort.md
+++ b/.changeset/great-adults-sort.md
@@ -1,0 +1,5 @@
+---
+"remark-shiki-twoslash": patch
+---
+
+Fixes an unreleased typo

--- a/.changeset/great-adults-sort.md
+++ b/.changeset/great-adults-sort.md
@@ -2,4 +2,4 @@
 "remark-shiki-twoslash": patch
 ---
 
-Fixes an unreleased typo
+Fixes a typo that prevent PnP environments to be properly detected

--- a/packages/remark-shiki-twoslash/src/caching.ts
+++ b/packages/remark-shiki-twoslash/src/caching.ts
@@ -42,7 +42,7 @@ export const cachedTwoslashCall = (
     return join(pnp.getPackageInformation(pnp.topLevelLocator).packageLocation, "node_modules", ".cache", "twoslash");
   };
 
-  const cacheRoot = process.env.pnp
+  const cacheRoot = process.versions.pnp
     ? getPnpCache()
     : getNmCache();
 


### PR DESCRIPTION
I made a typo in #115: `process.env.pnp` should be `process.versions.pnp`.

Tested locally using `yarn link` (weirdly, building the package using `pnpm pack` didn't work ... I got [this error](https://user-images.githubusercontent.com/1037931/135528526-8254fb0e-14e1-41bb-8e9f-076b2fb3ac1a.png), without stacktraces; doesn't seem related to my change, though).