### PR TITLE
Fix error in playground example

### DIFF
--- a/site/components/docs/Queries.mdx
+++ b/site/components/docs/Queries.mdx
@@ -8,7 +8,7 @@ Using `^?` you can pull out type information about a particular identifier in th
 
 ```ts twoslash
 const hi = "Hello"
-const msg = hi + ", world
+const msg = hi + ", world"
 //    ^?
 ```
 


### PR DESCRIPTION
There's a missing `"` in the first code snippet that causes a failure:

https://shikijs.github.io/twoslash/playground?#code/MYewdgzgLgBAFgSxgXhgIgBIFMA2ORoBQoksAthAOYrxIDU6ANDAO4gBOOAJoQPS8xBMAHoB+IA