### PR TITLE
Export `Options` type for remark plugin

### DIFF
--- a/.changeset/cool-trains-build.md
+++ b/.changeset/cool-trains-build.md
@@ -1,0 +1,5 @@
+---
+"remark-shiki-twoslash": patch
+---
+
+Export `Options` type for remark plugin

--- a/packages/remark-shiki-twoslash/src/index.ts
+++ b/packages/remark-shiki-twoslash/src/index.ts
@@ -135,11 +135,13 @@ type RemarkCodeNode = Node & {
   twoslash?: TwoSlashReturn
 }
 
+export type Options = UserConfigSettings
+
 /**
  * Synchronous outer function, async inner function, which is how the remark
  * async API works.
  */
-function remarkTwoslash(settings: UserConfigSettings = {}) {
+function remarkTwoslash(settings: Options = {}) {
   if (!highlighterCache.has(settings)) {
     highlighterCache.set(settings, highlightersFromSettings(settings))
   }


### PR DESCRIPTION
It would be nice to be able to do this:
```js
import remarkShikiTwoslash, { type Options } from "remark-shiki-twoslash";
```

Instead of this:
```js
import remarkShikiTwoslash from "remark-shiki-twoslash";
import { type UserConfigSettings as Options } from "shiki-twoslash";
```

I named the export `Options` to match the convention of recent releases of remark/rehype packages:
- https://github.com/rehypejs/rehype-autolink-headings#types
- https://github.com/remarkjs/remark-gfm#types
- https://github.com/rehypejs/rehype-raw#types