### PR TITLE
Fixes typo in the symbol name

### DIFF
--- a/.changeset/mighty-maps-kneel.md
+++ b/.changeset/mighty-maps-kneel.md
@@ -1,0 +1,5 @@
+---
+"remark-shiki-twoslash": patch
+---
+
+Fixes cache path calculation under PnP environments

--- a/packages/remark-shiki-twoslash/src/caching.ts
+++ b/packages/remark-shiki-twoslash/src/caching.ts
@@ -40,7 +40,7 @@ export const cachedTwoslashCall = (
   const getPnpCache = () => {
     try {
       const pnp = require("pnpapi");
-      return join(pnp.getPackageInformation(pnp.topLevelLocator).packageLocation, "node_modules", ".cache", "twoslash");
+      return join(pnp.getPackageInformation(pnp.topLevel).packageLocation, "node_modules", ".cache", "twoslash");
     } catch (error) {
       return getNmCache()
     }


### PR DESCRIPTION
The cache calculation was using the wrong variable name, sometimes causing incorrect results.