### PR TITLE
Escape code within Twoslash failure messages

### DIFF
--- a/.changeset/fifty-rabbits-mix.md
+++ b/.changeset/fifty-rabbits-mix.md
@@ -1,0 +1,5 @@
+---
+"remark-shiki-twoslash": patch
+---
+
+HTML characters in the code block within Twoslash failure messages are now escaped. This resolves an issue where generics that throw TypeScript errors caused a `remark` exception because it interpreted `<` as the beginning of an HTML element.

--- a/packages/remark-shiki-twoslash/src/exceptionMessageDOM.ts
+++ b/packages/remark-shiki-twoslash/src/exceptionMessageDOM.ts
@@ -2,6 +2,10 @@ import type { Node } from "unist"
 
 import {TwoslashError} from "@typescript/twoslash"
 
+function escapeHtml(html: string) {
+  return html.replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
 export const setupNodeForTwoslashException = (code: string, node: Node, error: unknown) => {
     const css = `<style>
 @import url('http://fonts.cdnfonts.com/css/caslon-os'); 
@@ -120,7 +124,7 @@ export const setupNodeForTwoslashException = (code: string, node: Node, error: u
         eLog(error)
     }
 
-    const codeSample = `<p>Raising Code:</p><pre class='twoslash-exception-code'><code>${code}</code></pre>`
+    const codeSample = `<p>Raising Code:</p><pre class='twoslash-exception-code'><code>${escapeHtml(code)}</code></pre>`
 
     const html = `
     <a href='#twoslash-error'><div class='twoslash-fixed-error-note'><span class='twoslash-error-color'></span>Twoslash failure</div></a>


### PR DESCRIPTION
Hi there!

This PR resolves an issue I was running into when using `remark-shiki-twoslash` with `@mdx-js/loader`. 

When using a twoslash code block with a TypeScript generic that has a type error, `@mdx-js/loader` throws an exception when attempting to render the Twoslash failure message block.

Here's the code block I was trying to use:

````
```ts twoslash
type MyPick<T, K> = {
  [Key in K]: T[Key]
}
```
````

This is the exception message: ``Error: Cannot turn `t, ` into a JSX identifier``. If I rename `T` to `R`, it becomes ``Error: Cannot turn `r,` into a JSX identifier``, and so on. It seems like `remark` reads `<` as the start of an element.

I was able to track this down to the fact that the code isn't escaped in `setupNodeForTwoslashException`. Escaping the code allows the failure to render as expected:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/1954752/156710719-bd732516-55b4-4403-b0b5-32c632177066.png">

It's also possible this is only happening because I'm using `rehype-raw` (due to #125), but I have no way to be sure since I can't render _anything_ if I don't use it.