### PR TITLE
Handle errors spanning multiple tokens

### DIFF
--- a/.changeset/tall-moons-study.md
+++ b/.changeset/tall-moons-study.md
@@ -1,0 +1,15 @@
+---
+"shiki-twoslash": minor
+---
+
+Added support for highlighting errors that span multiple tokens.
+
+Previously, error highlighting checked each token in a line to see if an error should be applied. This failed to apply an error highlight when the error spanned multiple tokens, like `T`+`[`+`Key`+`]` in the following example:
+
+```ts
+type MyPick<T, K> = {
+  [Key in K]: T[Key];
+};
+```
+
+`T[Key]` will now be correctly highlighted as an error.

--- a/packages/shiki-twoslash/src/renderers/twoslash.ts
+++ b/packages/shiki-twoslash/src/renderers/twoslash.ts
@@ -104,7 +104,21 @@ export function twoslashRenderer(lines: Lines, options: HtmlRendererOptions & Tw
           return result
         }
 
-        const errorsInToken = errors.filter(findTokenFunc(tokenPos))
+        const isTokenWithinErrorRange = (start: number) => (e: any) => 
+          start >= e.character && start + token.content.length <= e.character + e.length
+
+        const isTokenWithinErrorRangeDebug = (start: number) => (e: any) => {
+          const result = start >= e.character && start + token.content.length <= e.character + e.length
+          // prettier-ignore
+          console.log(result, token.content ,start, '>=', e.character, '&&', start + token.content.length, '<=', e.character + e.length)
+          if (result) {
+            console.log("Found:", e)
+            console.log("Inside:", token)
+          }
+          return result
+        }
+
+        const errorsInToken = errors.filter(isTokenWithinErrorRange(tokenPos))
         const lspResponsesInToken = lspValues.filter(findTokenFunc(tokenPos))
         const queriesInToken = queries.filter(findTokenFunc(tokenPos))
 


### PR DESCRIPTION
This PR resolves #144 by creating a new function that checks whether each token is within the _range_ of an error (`e.character` to `e.character + e.length`). Checking the range produces the correct results (`T[Key]` is highlighted as an error):

<img width="578" alt="image" src="https://user-images.githubusercontent.com/1954752/156839720-985a7f20-65b5-400c-87ef-48f2a179cf1c.png">

This function replaces `findTokenFunc` _only_ when handling errors (lsp responses + queries still use `findTokenFunc`).

I also added `isTokenWithinErrorRangeDebug` which is similar to `findTokenFuncDebug` for any future debugging needs.