### PR TITLE
Escape HTML in error message/recommendation

### DIFF
--- a/.changeset/green-colts-battle.md
+++ b/.changeset/green-colts-battle.md
@@ -1,0 +1,5 @@
+---
+"remark-shiki-twoslash": patch
+---
+
+Escape HTML in error message/recommendation

--- a/packages/remark-shiki-twoslash/src/exceptionMessageDOM.ts
+++ b/packages/remark-shiki-twoslash/src/exceptionMessageDOM.ts
@@ -87,9 +87,9 @@ export const setupNodeForTwoslashException = (code: string, node: Node, error: u
 
     const bodyFromTwoslashError = (error: TwoslashError) =>  {
         return `
-<h3>${error.title}</h3>
-<p>${error.description.replace(/(?:\r\n|\r|\n)/g, '<br>')}</p>
-<code>${error.recommendation.replace(/(?:\r\n|\r|\n)/g, '<br>')}</code>
+<h3>${escapeHtml(error.title)}</h3>
+<p>${escapeHtml(error.description).replace(/(?:\r\n|\r|\n)/g, "<br>")}</p>
+<code>${escapeHtml(error.recommendation).replace(/(?:\r\n|\r|\n)/g, "<br>")}</code>
 `
     }
 


### PR DESCRIPTION
When error titles/descriptions/recommendations have angle brackets in them, they don't display correctly because they are not escaped. In my case, the `error.recommendation` property had angle brackets in it because the message contained generics.

This PR escapes the text in those positions, so they display correctly.