### PR TITLE
feat: upgrade shiki to 0.10.1

### DIFF
--- a/.changeset/lazy-poets-complain.md
+++ b/.changeset/lazy-poets-complain.md
@@ -1,0 +1,8 @@
+---
+"eleventy-plugin-shiki-twoslash": minor
+"markdown-it-shiki-twoslash": minor
+"remark-shiki-twoslash": minor
+"shiki-twoslash": minor
+---
+
+Bump version of "shiki" to 0.10.1

--- a/packages/eleventy-plugin-shiki-twoslash/package.json
+++ b/packages/eleventy-plugin-shiki-twoslash/package.json
@@ -25,7 +25,7 @@
     "typescript": ">3"
   },
   "devDependencies": {
-    "shiki": "0.9.11",
+    "shiki": "0.10.1",
     "shiki-twoslash": "3.0.2"
   }
 }

--- a/packages/markdown-it-shiki-twoslash/package.json
+++ b/packages/markdown-it-shiki-twoslash/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "^25.1.3",
     "@types/markdown-it": "^12.0.1",
     "markdown-it": "^12.0.6",
-    "shiki": "0.9.11",
+    "shiki": "0.10.1",
     "shiki-twoslash": "3.0.2",
     "tslib": "^1.10.0",
     "typescript": ">3"

--- a/packages/remark-shiki-twoslash/package.json
+++ b/packages/remark-shiki-twoslash/package.json
@@ -31,7 +31,7 @@
     "@typescript/vfs": "1.3.4",
     "fenceparser": "^1.1.0",
     "regenerator-runtime": "^0.13.7",
-    "shiki": "0.9.11",
+    "shiki": "0.10.1",
     "shiki-twoslash": "3.0.2",
     "tslib": "2.1.0",
     "typescript": ">3",

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@typescript/twoslash": "3.1.0",
     "@typescript/vfs": "1.3.4",
-    "shiki": "0.9.11",
+    "shiki": "0.10.1",
     "typescript": ">3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
     specifiers:
       deasync: ^0.1.21
       remark-shiki-twoslash: 3.0.9
-      shiki: 0.9.11
+      shiki: 0.10.1
       shiki-twoslash: 3.0.2
       typescript: '>3'
     dependencies:
@@ -55,7 +55,7 @@ importers:
       remark-shiki-twoslash: link:../remark-shiki-twoslash
       typescript: 4.3.2
     devDependencies:
-      shiki: 0.9.11
+      shiki: 0.10.1
       shiki-twoslash: link:../shiki-twoslash
 
   packages/gatsby-remark-shiki-twoslash:
@@ -87,7 +87,7 @@ importers:
       deasync: ^0.1.21
       markdown-it: ^12.0.6
       remark-shiki-twoslash: 3.0.9
-      shiki: 0.9.11
+      shiki: 0.10.1
       shiki-twoslash: 3.0.2
       tslib: ^1.10.0
       typescript: '>3'
@@ -99,7 +99,7 @@ importers:
       '@types/jest': 25.2.3
       '@types/markdown-it': 12.0.1
       markdown-it: 12.0.6
-      shiki: 0.9.11
+      shiki: 0.10.1
       shiki-twoslash: link:../shiki-twoslash
       tslib: 1.14.1
       typescript: 4.3.2
@@ -115,7 +115,7 @@ importers:
       fenceparser: ^1.1.0
       regenerator-runtime: ^0.13.7
       rehype-stringify: ^6.0.1
-      shiki: 0.9.11
+      shiki: 0.10.1
       shiki-twoslash: 3.0.2
       tsdx: ^0.14.1
       tslib: 2.1.0
@@ -127,7 +127,7 @@ importers:
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.0
       regenerator-runtime: 0.13.7
-      shiki: 0.9.11
+      shiki: 0.10.1
       shiki-twoslash: link:../shiki-twoslash
       tslib: 2.1.0
       typescript: 4.3.2
@@ -151,7 +151,7 @@ importers:
       jest-file-snapshot: ^0.5.0
       prettier: ^2.3.0
       remark: ^13.0.0
-      shiki: 0.9.11
+      shiki: 0.10.1
       tsdx: ^0.14.1
       tslib: ^1.10.0
       typescript: '>3'
@@ -159,7 +159,7 @@ importers:
     dependencies:
       '@typescript/twoslash': 3.1.0
       '@typescript/vfs': 1.3.4
-      shiki: 0.9.11
+      shiki: 0.10.1
       typescript: 4.3.2
     devDependencies:
       '@types/jest': 25.2.3
@@ -2048,7 +2048,7 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 3.0.0
       exit: 0.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-changed-files: 25.5.0
       jest-config: 25.5.4
       jest-haste-map: 25.5.1
@@ -2194,7 +2194,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.7
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       istanbul-lib-coverage: 3.0.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -2210,7 +2210,7 @@ packages:
       terminal-link: 2.1.1
       v8-to-istanbul: 4.1.4
     optionalDependencies:
-      node-notifier: registry.npmjs.org/node-notifier/6.0.0
+      node-notifier: 6.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2257,7 +2257,7 @@ packages:
     engines: {node: '>= 8.3'}
     dependencies:
       callsites: 3.1.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       source-map: 0.6.1
     dev: true
 
@@ -2295,7 +2295,7 @@ packages:
     engines: {node: '>= 8.3'}
     dependencies:
       '@jest/test-result': 25.5.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-haste-map: 25.5.1
       jest-runner: 25.5.4
       jest-runtime: 25.5.4
@@ -2311,7 +2311,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/test-result': 27.0.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-haste-map: 27.0.5
       jest-runtime: 27.0.5
     transitivePeerDependencies:
@@ -2328,7 +2328,7 @@ packages:
       chalk: 3.0.0
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-haste-map: 25.5.1
       jest-regex-util: 25.2.6
       jest-util: 25.5.0
@@ -3444,7 +3444,7 @@ packages:
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 25.5.0_@babel+core@7.14.3
       chalk: 3.0.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -3500,7 +3500,7 @@ packages:
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 27.0.1_@babel+core@7.14.6
       chalk: 4.1.1
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4677,7 +4677,7 @@ packages:
       esutils: 2.0.3
       optionator: 0.8.3
     optionalDependencies:
-      source-map: registry.npmjs.org/source-map/0.6.1
+      source-map: 0.6.1
     dev: true
 
   /escodegen/2.0.0:
@@ -5399,6 +5399,14 @@ packages:
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
     dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
@@ -6368,7 +6376,7 @@ packages:
       '@jest/types': 25.5.0
       chalk: 3.0.0
       exit: 0.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       import-local: 3.0.2
       is-ci: 2.0.0
       jest-config: 25.5.4
@@ -6425,7 +6433,7 @@ packages:
       chalk: 3.0.0
       deepmerge: 4.2.2
       glob: 7.1.7
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-environment-jsdom: 25.5.0
       jest-environment-node: 25.5.0
       jest-get-type: 25.2.6
@@ -6637,7 +6645,7 @@ packages:
       '@types/graceful-fs': 4.1.5
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-serializer: 25.5.0
       jest-util: 25.5.0
       jest-worker: 25.5.0
@@ -6646,7 +6654,7 @@ packages:
       walker: 1.0.7
       which: 2.0.2
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     dev: true
 
   /jest-haste-map/26.6.2:
@@ -6667,7 +6675,7 @@ packages:
       sane: 4.1.0
       walker: 1.0.7
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     dev: true
 
   /jest-haste-map/27.0.5:
@@ -6788,7 +6796,7 @@ packages:
       '@jest/types': 25.5.0
       '@types/stack-utils': 1.0.1
       chalk: 3.0.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       micromatch: 4.0.4
       slash: 3.0.0
       stack-utils: 1.0.5
@@ -6890,7 +6898,7 @@ packages:
       '@jest/types': 25.5.0
       browser-resolve: 1.11.3
       chalk: 3.0.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-pnp-resolver: 1.2.2_jest-resolve@25.5.1
       read-pkg-up: 7.0.1
       realpath-native: 2.0.0
@@ -6923,7 +6931,7 @@ packages:
       '@jest/types': 25.5.0
       chalk: 3.0.0
       exit: 0.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-config: 25.5.4
       jest-docblock: 25.3.0
       jest-haste-map: 25.5.1
@@ -6993,7 +7001,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.7
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-config: 25.5.4
       jest-haste-map: 25.5.1
       jest-message-util: 25.5.0
@@ -7052,7 +7060,7 @@ packages:
     resolution: {integrity: sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==}
     engines: {node: '>= 8.3'}
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
     dev: true
 
   /jest-serializer/26.6.2:
@@ -7080,7 +7088,7 @@ packages:
       '@types/prettier': 1.19.1
       chalk: 3.0.0
       expect: 25.5.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       jest-diff: 25.5.0
       jest-get-type: 25.2.6
       jest-matcher-utils: 25.5.0
@@ -7130,7 +7138,7 @@ packages:
     dependencies:
       '@jest/types': 25.5.0
       chalk: 3.0.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       is-ci: 2.0.0
       make-dir: 3.1.0
     dev: true
@@ -7467,7 +7475,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
     dev: true
 
   /jsonfile/6.1.0:
@@ -7475,7 +7483,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
     dev: true
 
   /jsprim/1.4.1:
@@ -7579,7 +7587,7 @@ packages:
     resolution: {integrity: sha1-L19Fq5HjMhYjT9U62rZo607AmTs=}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.6
+      graceful-fs: 4.2.6
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -7711,11 +7719,6 @@ packages:
       pseudomap: 1.0.2
       yallist: 2.1.2
     dev: true
-
-  /lru-cache/5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-    dependencies:
-      yallist: 3.1.1
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -8097,6 +8100,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /node-notifier/6.0.0:
+    resolution: {integrity: sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==}
+    requiresBuild: true
+    dependencies:
+      growly: 1.3.0
+      is-wsl: 2.2.0
+      semver: 6.3.0
+      shellwords: 0.1.1
+      which: 1.3.1
+    dev: true
+    optional: true
+
   /node-releases/1.1.73:
     resolution: {integrity: sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==}
     dev: true
@@ -8237,11 +8252,6 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
-
-  /onigasm/2.2.5:
-    resolution: {integrity: sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==}
-    dependencies:
-      lru-cache: 5.1.1
 
   /optionator/0.8.3:
     resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
@@ -9383,11 +9393,11 @@ packages:
     dev: true
     optional: true
 
-  /shiki/0.9.11:
-    resolution: {integrity: sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==}
+  /shiki/0.10.1:
+    resolution: {integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==}
     dependencies:
       jsonc-parser: 3.0.0
-      onigasm: 2.2.5
+      vscode-oniguruma: 1.6.2
       vscode-textmate: 5.2.0
 
   /side-channel/1.0.4:
@@ -9457,7 +9467,7 @@ packages:
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
-      source-map: registry.npmjs.org/source-map/0.5.7
+      source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
     dev: true
@@ -10528,6 +10538,9 @@ packages:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
+  /vscode-oniguruma/1.6.2:
+    resolution: {integrity: sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==}
+
   /vscode-textmate/5.2.0:
     resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}
 
@@ -10818,9 +10831,6 @@ packages:
     resolution: {integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=}
     dev: true
 
-  /yallist/3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
@@ -10894,27 +10904,6 @@ packages:
     resolution: {integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz}
     name: graceful-fs
     version: 4.2.6
-    dev: true
-
-  registry.npmjs.org/node-notifier/6.0.0:
-    resolution: {integrity: sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz}
-    name: node-notifier
-    version: 6.0.0
-    requiresBuild: true
-    dependencies:
-      growly: 1.3.0
-      is-wsl: 2.2.0
-      semver: 6.3.0
-      shellwords: 0.1.1
-      which: 1.3.1
-    dev: true
-    optional: true
-
-  registry.npmjs.org/source-map/0.5.7:
-    resolution: {integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz}
-    name: source-map
-    version: 0.5.7
-    engines: {node: '>=0.10.0'}
     dev: true
 
   registry.npmjs.org/source-map/0.6.1:

--- a/site/package.json
+++ b/site/package.json
@@ -14,7 +14,7 @@
     "remark-shiki-twoslash": "link:../packages/remark-shiki-twoslash",
     "shiki-twoslash": "link:../packages/shiki-twoslash",
     "twoslash-cli": "link:../packages/twoslash-cli",
-    "shiki": "0.9.11"
+    "shiki": "0.10.1"
   },
   "dependencies": {
     "@mdx-js/loader": "^1.6.22",
@@ -31,7 +31,7 @@
     "react-tabs": "^3.2.2",
     "remark-shiki-twoslash": "3.0.5",
     "sass": "^1.37.5",
-    "shiki": "0.9.11",
+    "shiki": "0.10.1",
     "shiki-twoslash": "link:../packages/shiki-twoslash",
     "ts-debounce": "^3.0.0",
     "vscode-theme-generator": "^0.1.5"


### PR DESCRIPTION
This PR upgrades the upstream dependency of `shiki` to `0.10.1`.

I was unable to find a changelog of what was changed in `shiki@0.10.0` over `0.9.15`  outside of this list of commits:

https://github.com/shikijs/shiki/compare/1d5379138d706239c6bf9c337f655d40ad0bd92e...v0.10.0

And looking through each of the commits, I couldn't see an obvious breaking API that would require major refactor work.

Closes #155