### PR TITLE
Use pnpm rather than npx for bootstrapping

### DIFF
--- a/packages/docusaurus-preset-shiki-twoslash/package.json
+++ b/packages/docusaurus-preset-shiki-twoslash/package.json
@@ -17,7 +17,7 @@
   "typings": "./index.d.ts",
   "scripts": {
     "bootstrap": "echo 'NOOP'",
-    "build": "npx tsc index.js --declaration --allowJs --emitDeclarationOnly --esModuleInterop --target es2018 -moduleResolution node",
+    "build": "pnpm exec tsc index.js --declaration --allowJs --emitDeclarationOnly --esModuleInterop --target es2018 -moduleResolution node",
     "test": "echo 'NOOP'",
     "lint": "echo 'NOOP'"
   },

--- a/packages/eleventy-plugin-shiki-twoslash/package.json
+++ b/packages/eleventy-plugin-shiki-twoslash/package.json
@@ -17,7 +17,7 @@
   "typings": "./index.d.ts",
   "scripts": {
     "bootstrap": "echo 'NOOP'",
-    "build": "npx tsc index.js --declaration --allowJs --emitDeclarationOnly --target es2018 -moduleResolution node"
+    "build": "pnpm exec tsc index.js --declaration --allowJs --emitDeclarationOnly --target es2018 -moduleResolution node"
   },
   "dependencies": {
     "deasync": "^0.1.21",

--- a/packages/hexo-shiki-twoslash/package.json
+++ b/packages/hexo-shiki-twoslash/package.json
@@ -16,7 +16,7 @@
   "main": "./index.js",
   "scripts": {
     "bootstrap": "echo 'NOOP'",
-    "build": "npx tsc index.js --declaration --allowJs --emitDeclarationOnly  --target es2018 -moduleResolution node",
+    "build": "pnpm exec tsc index.js --declaration --allowJs --emitDeclarationOnly  --target es2018 -moduleResolution node",
     "test": "echo 'NOOP'",
     "lint": "echo 'NOOP'"
   },

--- a/packages/markdown-it-shiki-twoslash/package.json
+++ b/packages/markdown-it-shiki-twoslash/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "esbuild src/index.ts --outfile=dist/index.js --target=node12 --platform=node",
-    "bootstrap": "npx tsc src/index.ts --declaration  --emitDeclarationOnly --outdir dist --esModuleInterop",
+    "bootstrap": "pnpm exec tsc src/index.ts --declaration  --emitDeclarationOnly --outdir dist --esModuleInterop",
     "prepublishOnly": "npm run build; npm run bootstrap"
   },
   "dependencies": {


### PR DESCRIPTION
Without this I hit workspace issues when running `pnpm boostrap`.

```
╭─[00:00]: captbaritone at moffo in ~/projects/twoslash on branch*
╰─➤ pnpm bootstrap

> shiki-twoslash-monorepo@ bootstrap /Users/captbaritone/projects/twoslash
> pnpm recursive run --workspace-concurrency 1 build  && md-magic

Scope: all 10 workspace projects

> shiki-twoslash-monorepo@ build /Users/captbaritone/projects/twoslash
> pnpm run build -r && md-magic

Scope: all 10 workspace projects

> shiki-twoslash@3.1.0 build /Users/captbaritone/projects/twoslash/packages/shiki-twoslash
> tsdx build

@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
✓ Creating entry file 570 ms
⠹ Building modules  58%                 0.9s, estimated 1.6s
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
✓ Building modules 2.4 secs

> remark-shiki-twoslash@3.1.0 build /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash
> tsdx build

@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
✓ Creating entry file 560 ms
⠙ Building modules  6%                  0.1s, estimated 1.5s
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
✓ Building modules 1.4 secs

> docusaurus-preset-shiki-twoslash@1.1.38 build /Users/captbaritone/projects/twoslash/packages/docusaurus-preset-shiki-twoslash
> npx tsc index.js --declaration --allowJs --emitDeclarationOnly --esModuleInterop --target es2018 -moduleResolution node

Error: must not have multiple workspaces with the same name
package '@types/node' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/docusaurus-preset-shiki-twoslash/node_modules/@types/node
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/@types/node
    /Users/captbaritone/projects/twoslash/packages/twoslash-cli/node_modules/@types/node
package 'remark-shiki-twoslash' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/docusaurus-preset-shiki-twoslash/node_modules/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/eleventy-plugin-shiki-twoslash/node_modules/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/gatsby-remark-shiki-twoslash/node_modules/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/hexo-shiki-twoslash/node_modules/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/twoslash-cli/node_modules/remark-shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/vuepress-plugin-shiki-twoslash/node_modules/remark-shiki-twoslash
package 'typescript' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/docusaurus-preset-shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/eleventy-plugin-shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/gatsby-remark-shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/hexo-shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/twoslash-cli/node_modules/typescript
    /Users/captbaritone/projects/twoslash/packages/vuepress-plugin-shiki-twoslash/node_modules/typescript
package 'deasync' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/eleventy-plugin-shiki-twoslash/node_modules/deasync
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/deasync
package 'shiki-twoslash' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/eleventy-plugin-shiki-twoslash/node_modules/shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/shiki-twoslash
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash
package 'shiki' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/eleventy-plugin-shiki-twoslash/node_modules/shiki
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/shiki
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/shiki
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/shiki
package 'tslib' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/gatsby-remark-shiki-twoslash/node_modules/tslib
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/tslib
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/tslib
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/tslib
package 'unist-util-visit' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/gatsby-remark-shiki-twoslash/node_modules/unist-util-visit
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/unist-util-visit
    /Users/captbaritone/projects/twoslash/packages/twoslash-cli/node_modules/unist-util-visit
package '@types/jest' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/markdown-it-shiki-twoslash/node_modules/@types/jest
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/@types/jest
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/@types/jest
package '@typescript/twoslash' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/@typescript/twoslash
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/@typescript/twoslash
package '@typescript/vfs' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/@typescript/vfs
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/@typescript/vfs
package 'fenceparser' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/fenceparser
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/fenceparser
package 'tsdx' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/tsdx
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/tsdx
package 'unified' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/remark-shiki-twoslash/node_modules/unified
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/unified
package 'remark' has conflicts in the following paths:
    /Users/captbaritone/projects/twoslash/packages/shiki-twoslash/node_modules/remark
    /Users/captbaritone/projects/twoslash/packages/twoslash-cli/node_modules/remark
    at getError (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/node_modules/@npmcli/map-workspaces/lib/index.js:66:24)
    at mapWorkspaces (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/node_modules/@npmcli/map-workspaces/lib/index.js:146:11)
    at async Config.loadLocalPrefix (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/node_modules/@npmcli/config/lib/index.js:600:28)
    at async Config.loadProjectConfig (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/node_modules/@npmcli/config/lib/index.js:538:5)
    at async Config.load (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/node_modules/@npmcli/config/lib/index.js:272:5)
    at async [_load] (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/lib/npm.js:241:5)
    at async module.exports (/Users/captbaritone/.nvm/versions/node/v18.7.0/lib/node_modules/npm/lib/cli.js:59:5)
/Users/captbaritone/projects/twoslash/packages/docusaurus-preset-shiki-twoslash:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  docusaurus-preset-shiki-twoslash@1.1.38 build: `npx tsc index.js --declaration --allowJs --emitDeclarationOnly --esModuleInterop --target es2018 -moduleResolution node`
Exit status 1

> eleventy-plugin-shiki-twoslash@1.1.0 build /Users/captbaritone/projects/twoslash/packages/eleventy-plugin-shiki-twoslash
> npx tsc index.js --declaration --allowJs --emitDeclarationOnly --target es2018 -moduleResolution node

 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  shiki-twoslash-monorepo@ build: `pnpm run build -r && md-magic`
Exit status 1

> shiki-twoslash@3.1.0 build /Users/captbaritone/projects/twoslash/packages/shiki-twoslash
> tsdx build

 ELIFECYCLE  Command failed with exit code 1.