### PR TITLE
feat(extensions): register commands and providers also for MDX files

### DIFF
--- a/extensions/vscode-twoslash/package.json
+++ b/extensions/vscode-twoslash/package.json
@@ -14,7 +14,8 @@
     "Linters"
   ],
   "activationEvents": [
-    "onLanguage:markdown"
+    "onLanguage:markdown",
+    "onLanguage:mdx"
   ],
   "contributes": {
   },

--- a/extensions/vscode-twoslash/src/extension.ts
+++ b/extensions/vscode-twoslash/src/extension.ts
@@ -10,7 +10,7 @@ export function activate(context: vscode.ExtensionContext) {
   
   // Provides the buttons
   const codelens = new SnapshotCodeLensProvider(runner)
-  const codelensD = vscode.languages.registerCodeLensProvider({ pattern: '**/*.md' }, codelens)
+  const codelensD = vscode.languages.registerCodeLensProvider({ pattern: "**/*.{md,mdx}" }, codelens);
   
   // So that a runner can tell the code actions to update after a run
   runner.codeLensDidChange = codelens.onDidChange
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   // Provides a hover with the full info for exceptions
-  const hoverDispose = vscode.languages.registerHoverProvider('markdown', {
+  const hoverDispose = vscode.languages.registerHoverProvider(['markdown', 'mdx'], {
     provideHover(document, position, token) {
       const char = document.offsetAt(position)
       const codeblock = runner.stateForSampleAtPosition(char)
@@ -88,7 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 
   // Provides a hover with the full info for exceptions
-  const completionDispose = vscode.languages.registerCompletionItemProvider('markdown', {
+  const completionDispose = vscode.languages.registerCompletionItemProvider(['markdown', 'mdx'], {
       provideCompletionItems: (document, position, cancel, context) => {
 
         const results: vscode.CompletionItem[] = []


### PR DESCRIPTION
I found that the [MDX plugin](https://github.com/mdx-js/vscode-mdx/blob/a5d7c030e1120b6a8e827d028818352c7d9dc46e/package.json#L80) chose `mdx` as the language identifier. This PR updates all places where commands/providers are registered to also include mdx files. It also adds an additional activation event for the mdx language.

This PR fixes the issue of auto-completion not working in MDX files (#172). However, syntax highlighting of TypeScript code within JSX blocks still doesn't work. Which part of the code is responsible for the highlighting? I couldn't figure it out just by reading the code and I couldn't make the debugger work, either.

Would you have any pointers for me, @orta?

<img width="1036" alt="Screenshot 2022-11-06 at 01 55 01" src="https://user-images.githubusercontent.com/5737996/200125938-ae9bbea8-b28a-46fc-80dc-dbfa0c2ae6be.png">
