### PR TITLE
Fixes dependencies

### DIFF
--- a/.changeset/slow-poets-speak.md
+++ b/.changeset/slow-poets-speak.md
@@ -1,0 +1,6 @@
+---
+"remark-shiki-twoslash": patch
+"shiki-twoslash": patch
+---
+
+Moves typescript to peer dependencies

--- a/packages/remark-shiki-twoslash/package.json
+++ b/packages/remark-shiki-twoslash/package.json
@@ -35,8 +35,10 @@
     "shiki": "0.10.1",
     "shiki-twoslash": "3.1.0",
     "tslib": "2.1.0",
-    "typescript": ">3",
     "unist-util-visit": "^2.0.0"
+  },
+  "peerDependencies": {
+    "typescript": ">3"
   },
   "devDependencies": {
     "@mdx-js/mdx": "^1.6.2",

--- a/packages/remark-shiki-twoslash/package.json
+++ b/packages/remark-shiki-twoslash/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@typescript/twoslash": "3.1.0",
     "@typescript/vfs": "1.3.4",
+    "@types/unist": "^2.0.0",
     "fenceparser": "^1.1.0",
     "regenerator-runtime": "^0.13.7",
     "shiki": "0.10.1",

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -30,12 +30,14 @@
   "dependencies": {
     "@typescript/twoslash": "3.1.0",
     "@typescript/vfs": "1.3.4",
-    "shiki": "0.10.1",
+    "fenceparser": "^1.1.0",
+    "shiki": "0.10.1"
+  },
+  "peerDependencies": {
     "typescript": ">3"
   },
   "devDependencies": {
     "@types/jest": "^25.1.3",
-    "fenceparser": "^1.1.0",
     "gray-matter": "^4.0.3",
     "jest-file-snapshot": "^0.5.0",
     "prettier": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,7 @@ importers:
       unified: ^8.4.2
       unist-util-visit: ^2.0.0
     dependencies:
+      '@types/unist': 2.0.3
       '@typescript/twoslash': 3.1.0
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.0
@@ -136,17 +137,16 @@ importers:
       shiki: 0.10.1
       shiki-twoslash: link:../shiki-twoslash
       tslib: 2.1.0
-      typescript: 4.3.2
       unist-util-visit: 2.0.3
     devDependencies:
       '@mdx-js/mdx': 1.6.22
       '@types/jest': 25.2.3
       '@types/node': 14.14.31
-      '@types/unist': 2.0.3
       babel-jest: 26.6.3
       esbuild: 0.12.9
       rehype-stringify: 6.0.1
       tsdx: 0.14.1_@types+node@14.14.31
+      typescript: 4.3.2
       unified: 8.4.2
 
   packages/shiki-twoslash:
@@ -162,16 +162,14 @@ importers:
       shiki: 0.10.1
       tsdx: ^0.14.1
       tslib: ^1.10.0
-      typescript: '>3'
       unified: ^8.4.2
     dependencies:
       '@typescript/twoslash': 3.1.0
       '@typescript/vfs': 1.3.4
+      fenceparser: 1.1.0
       shiki: 0.10.1
-      typescript: 4.3.2
     devDependencies:
       '@types/jest': 25.2.3
-      fenceparser: 1.1.0
       gray-matter: 4.0.3
       jest-file-snapshot: 0.5.0
       prettier: 2.3.0
@@ -5283,6 +5281,7 @@ packages:
   /fenceparser/1.1.0:
     resolution: {integrity: sha512-2/48W+LjGeYLYc7Z2WodoPv4xP4Bd9e2CsnnFZuzzoNkv+w8NyJKDD/EUhcwv9VkmXsnGtnDzZz6DNykD9JrlA==}
     engines: {node: '>=12'}
+    dev: false
 
   /figures/3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -10519,6 +10518,7 @@ packages:
   /unified/8.4.2:
     resolution: {integrity: sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==}
     dependencies:
+      '@types/unist': 2.0.3
       bail: 1.0.5
       extend: 3.0.2
       is-plain-obj: 2.1.0
@@ -10529,6 +10529,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.3
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twoslash-site",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -21,7 +21,7 @@
     "@next/mdx": "^11.0.1",
     "@types/express": "^4.17.12",
     "@types/mdx": "^2.0.2",
-    "docusaurus-preset-shiki-twoslash": "link:../packages/docusaurus-preset-shiki-twoslash",
+    "docusaurus-preset-shiki-twoslash": "1.1.38",
     "json": "^11.0.0",
     "monaco-editor": "^0.26.1",
     "next": "12.2.3",
@@ -30,16 +30,16 @@
     "react-dom": "17.0.2",
     "react-resizable": "^3.0.4",
     "react-tabs": "^3.2.2",
-    "remark-shiki-twoslash": "link:../packages/remark-shiki-twoslash",
+    "remark-shiki-twoslash": "3.1.0",
     "sass": "^1.37.5",
     "shiki": "0.10.1",
-    "shiki-twoslash": "link:../packages/shiki-twoslash",
+    "shiki-twoslash": "3.1.0",
     "ts-debounce": "^3.0.0",
     "vscode-theme-generator": "^0.1.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.15",
-    "twoslash-cli": "link:../packages/twoslash-cli",
+    "twoslash-cli": "1.3.21",
     "typescript": "^4.7.4"
   },
   "prettier": {


### PR DESCRIPTION
- Due to the `ReturnType` use [here](https://github.com/shikijs/twoslash/blob/main/packages/shiki-twoslash/src/utils.ts#L1-L3), the generated types for `shiki-twoslash` include a reference to `fenceparser`, which should then be in the `dependencies` listing.

- Similarly, the `import 'unist'` [here](https://github.com/arcanis/twoslash/blob/patch-2/packages/remark-shiki-twoslash/src/index.ts#L1) doesn't work out-of-the-box since `@types/unist` isn't listed in the dependencies (of note, the `unist` package doesn't exist, only `@types/unist` does).

- Since the intent is probably to use whatever TS version the consumer uses, `typescript` should be a peer dependency rather than a regular dependency (otherwise there's a chance some hoisting mess will happen, especially if the user happens to use a prerelease TS build, which won't semver-match the `>` predicate).

Fixes the following errors:

```
../.yarn/berry/cache/shiki-twoslash-npm-3.1.0-15ca70e21f-9.zip/node_modules/shiki-twoslash/dist/utils.d.ts:1:28 - error TS2307: Cannot find module 'fenceparser' or its corresponding type declarations.

1 import type { parse } from "fenceparser";
                             ~~~~~~~~~~~~~

.yarn/unplugged/remark-shiki-twoslash-npm-3.1.0-2bfe129f0f/node_modules/remark-shiki-twoslash/dist/index.d.ts:1:27 - error TS2307: Cannot find module 'unist' or its corresponding type declarations.

1 import type { Node } from "unist";
                            ~~~~~~~
```
