### PR TITLE
fix: completion result closing tag

### DIFF
--- a/.changeset/spotty-hairs-clean.md
+++ b/.changeset/spotty-hairs-clean.md
@@ -1,0 +1,5 @@
+---
+"shiki-twoslash": patch
+---
+
+Fixed renderer completion result closing tag.

--- a/packages/shiki-twoslash/src/renderers/twoslash.ts
+++ b/packages/shiki-twoslash/src/renderers/twoslash.ts
@@ -192,7 +192,7 @@ export function twoslashRenderer(lines: Lines, options: HtmlRendererOptions & Tw
                 .sort((l, r) => l.name.localeCompare(r.name))
                 .map(c => {
                   const after = c.name.substr(query.completionsPrefix?.length || 0)
-                  const name = `<span><span class='result-found'>${query.completionsPrefix || ""}</span>${after}<span>`
+                  const name = `<span><span class='result-found'>${query.completionsPrefix || ""}</span>${after}</span>`
                   const isDeprecated = c.kindModifiers?.split(",").includes("deprecated")
                   const liClass = isDeprecated ? "deprecated" : ""
                   return `<li class='${liClass}'>${name}</li>`


### PR DESCRIPTION
Fixes closing tag for completion result.

---

Got the following error while using with Vitepress:

```
Element is missing end tag
```

With this code:

````markdown
```ts twoslash
// @noErrors
console.e
//       ^|
```
````

And inspecting the generated code (below), lead me to the syntax error.

```html
<pre class="shiki vitesse-dark twoslash lsp" style="background-color: #121212; color: #dbd7ca"><div class="language-id">ts</div><div class='code-container'><code><div class='line'><span style="color: #B8A965"><data-lsp lsp='var console: Console' >console</data-lsp></span><span style="color: #858585">.</span><span style="color: #B8A965"><data-lsp lsp='any' >e</data-lsp></span></div><div class='meta-line'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class='inline-completions'><ul class='dropdown'><li class=''><span><span class='result-found'>e</span>rror<span></li></ul></span></div></code><a class='playground-link' href='https://www.typescriptlang.org/play/#code/PTAEAEDsHsFECd7XgZwFAGNqRdANgKYB0BaIoFloAegD5A'>Try</a></div></pre>
```